### PR TITLE
Kafka headers name change from ce_hook_ to hook_

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM yolean/builder-quarkus:2c6e176109a4cb1850cb7f8fa56411d370e3f705@sha256:9d309b1c352b1334eff63902216dc950a54eaf4433e985ed68ad9f5231750b48 \
+FROM yolean/builder-quarkus:f7f5b1c5790e0c755e85bbc00d576875d4fa7bf5@sha256:d6bffbecb6c5ba48029206a39c1ee9292a4911b12283517b12cb64718cf0b871 \
   as dev
 
 COPY --chown=nonroot:nogroup pom.xml .
@@ -30,7 +30,7 @@ RUN test "$build" = "native-image" || mvn --batch-mode $build
 
 RUN test "$build" != "native-image" || mvn --batch-mode package -Pnative -Dmaven.test.skip=true
 
-FROM yolean/java:ccf1569eec4cea1b9fe0cb024021046f526cf7a1@sha256:6cf17f70498db56b7fda08d07098f9d5991fd8f8a6e3f1d38e9aa3ee89cef780 \
+FROM yolean/java:f7f5b1c5790e0c755e85bbc00d576875d4fa7bf5@sha256:ed802e9d138b0e0059698d01d930bda65241d70c286590667922a532552cc694 \
   as jvm
 
 WORKDIR /app
@@ -45,6 +45,6 @@ ENTRYPOINT [ "java", \
   "-cp", "./lib/*", \
   "-jar", "./app.jar" ]
 
-FROM yolean/runtime-quarkus:2c6e176109a4cb1850cb7f8fa56411d370e3f705@sha256:00758a8e8941e8e47c2fb9dd8a055972f62e55c5b91c8fedcf14603a2900e0a0
+FROM yolean/runtime-quarkus:f7f5b1c5790e0c755e85bbc00d576875d4fa7bf5@sha256:a75181747faceeaab2f360d9c19af06be79943182b8fd8666b1a7ef716ef3b47
 
 COPY --from=dev /workspace/rest/target/*-runner /usr/local/bin/quarkus

--- a/lib/src/main/java/se/yolean/kafka/hook/HookCloudEvent.java
+++ b/lib/src/main/java/se/yolean/kafka/hook/HookCloudEvent.java
@@ -1,0 +1,25 @@
+package se.yolean.kafka.hook;
+
+import io.cloudevents.CloudEvent;
+import se.yolean.kafka.hook.cloudevents.HookCustomFields;
+import se.yolean.kafka.hook.cloudevents.IncomingWebhookExtension;
+
+public class HookCloudEvent {
+
+  private final CloudEvent event;
+  private final IncomingWebhookExtension hook;
+
+  public HookCloudEvent(CloudEvent event, IncomingWebhookExtension hookCustomFields) {
+    this.event = event;
+    this.hook = hookCustomFields;
+  }
+
+  public CloudEvent getEvent() {
+    return event;
+  }
+
+  public HookCustomFields getCustomFields() {
+    return hook;
+  }
+
+}

--- a/lib/src/main/java/se/yolean/kafka/hook/Producer.java
+++ b/lib/src/main/java/se/yolean/kafka/hook/Producer.java
@@ -13,7 +13,6 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.cloudevents.CloudEvent;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.Startup;
 import io.quarkus.runtime.StartupEvent;
@@ -32,7 +31,7 @@ public class Producer {
 
   @Inject ProducerConfiguration config;
 
-  KafkaProducer<HookMessageKey, CloudEvent> producer = null;
+  KafkaProducer<HookMessageKey, HookCloudEvent> producer = null;
 
   void onStart(@Observes StartupEvent ev) {
     Map<String,Object> props = KafkaProps.fromQuarkusOutgoingConfig(config);
@@ -43,8 +42,8 @@ public class Producer {
     producer.close(KafkaProps.PRODUCER_CLOSE_TIMEOUT);
   }
 
-  public Future<RecordMetadata> send(HookMessageKey key, CloudEvent message) {
-    return producer.send(new ProducerRecord<HookMessageKey,CloudEvent>(config.getTopic(), key, message));
+  public Future<RecordMetadata> send(HookMessageKey key, HookCloudEvent message) {
+    return producer.send(new ProducerRecord<HookMessageKey,HookCloudEvent>(config.getTopic(), key, message));
   }
 
 }

--- a/lib/src/main/java/se/yolean/kafka/hook/cloudevents/HookCustomFields.java
+++ b/lib/src/main/java/se/yolean/kafka/hook/cloudevents/HookCustomFields.java
@@ -1,0 +1,18 @@
+package se.yolean.kafka.hook.cloudevents;
+
+import java.util.Set;
+
+public interface HookCustomFields {
+
+  public Set<String> getKeys();
+
+  public Object getValue(String key);
+
+  /**
+   * The CloudEvents spec handles typed values, but here we deal with HTTP headers.
+   * @param key from {@link #getKeys()}
+   * @return the string value as bytes
+   */
+  byte[] getValueBytes(String key);
+
+}

--- a/lib/src/main/java/se/yolean/kafka/hook/cloudevents/IncomingWebhookExtension.java
+++ b/lib/src/main/java/se/yolean/kafka/hook/cloudevents/IncomingWebhookExtension.java
@@ -4,10 +4,16 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import io.cloudevents.CloudEventExtensions;
-import io.cloudevents.Extension;
+/**
+ * Note that this "extension" fails to produce field names that comply with
+ * https://github.com/cloudevents/spec/blob/master/spec.md#attribute-naming-convention
+ */
+public class IncomingWebhookExtension implements HookCustomFields { //io.cloudevents.Extension {
 
-public class IncomingWebhookExtension implements Extension {
+  // @Override
+  // public void readFrom(CloudEventExtensions extensions) {
+  //   throw new UnsupportedOperationException("TODO this extension currently only only supports writing");
+  // }
 
   private Map<String,String> fields = new LinkedHashMap<>(10);
 
@@ -41,15 +47,15 @@ public class IncomingWebhookExtension implements Extension {
   public Object getValue(String key) {
     return fields.get(key);
   }
-  
+
   @Override
-  public Set<String> getKeys() {
-    return fields.keySet();
+  public byte[] getValueBytes(String key) {
+    return fields.get(key).getBytes();
   }
 
   @Override
-  public void readFrom(CloudEventExtensions extensions) {
-    throw new UnsupportedOperationException("TODO this extension currently only only supports writing");
+  public Set<String> getKeys() {
+    return fields.keySet();
   }
 
   @Override

--- a/lib/src/main/java/se/yolean/kafka/hook/http/KafkaHookResource.java
+++ b/lib/src/main/java/se/yolean/kafka/hook/http/KafkaHookResource.java
@@ -31,8 +31,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import se.yolean.kafka.hook.CloudeventConfiguration;
 import se.yolean.kafka.hook.CloudeventExtender;
+import se.yolean.kafka.hook.HookCloudEvent;
 import se.yolean.kafka.hook.LimitsConfiguration;
 import se.yolean.kafka.hook.Producer;
+import se.yolean.kafka.hook.cloudevents.IncomingWebhookExtension;
 import se.yolean.kafka.hook.types.v1.HookError;
 import se.yolean.kafka.hook.types.v1.HookMessageKey;
 import se.yolean.kafka.hook.types.v1.HookReceipt;
@@ -82,14 +84,15 @@ public class KafkaHookResource {
     HookError err = new HookError();
     byte[] data = payload.readAllBytes();
     // TODO handle too large payloads
-    CloudEvent message = CloudEventBuilder.v1()
+    IncomingWebhookExtension hookCustomFields = extensions.getHttp(headers, uri);
+    CloudEvent event = CloudEventBuilder.v1()
         .withId(id)
         .withType(eventtype)
         .withSource(getSource(uri))
         .withExtension(extensions.getTracing(headers))
-        .withExtension(extensions.getHttp(headers, uri))
         .withData(data)
         .build();
+    HookCloudEvent message = new HookCloudEvent(event, hookCustomFields);
     HookMessageKey key = new HookMessageKey();
     key.setId(id);
     key.setType(type);

--- a/lib/src/main/java/se/yolean/kafka/hook/serdes/CloudEventDeserializer.java
+++ b/lib/src/main/java/se/yolean/kafka/hook/serdes/CloudEventDeserializer.java
@@ -1,8 +1,0 @@
-package se.yolean.kafka.hook.serdes;
-
-import io.quarkus.runtime.annotations.RegisterForReflection;
-
-@RegisterForReflection
-public class CloudEventDeserializer extends
-    io.cloudevents.kafka.CloudEventDeserializer {
-}

--- a/lib/src/main/java/se/yolean/kafka/hook/serdes/CloudEventSerializer.java
+++ b/lib/src/main/java/se/yolean/kafka/hook/serdes/CloudEventSerializer.java
@@ -1,8 +1,0 @@
-package se.yolean.kafka.hook.serdes;
-
-import io.quarkus.runtime.annotations.RegisterForReflection;
-
-@RegisterForReflection
-public class CloudEventSerializer extends
-    io.cloudevents.kafka.CloudEventSerializer {
-}

--- a/lib/src/main/java/se/yolean/kafka/hook/serdes/HookCloudEventSerializer.java
+++ b/lib/src/main/java/se/yolean/kafka/hook/serdes/HookCloudEventSerializer.java
@@ -1,0 +1,38 @@
+package se.yolean.kafka.hook.serdes;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Serializer;
+
+import io.cloudevents.kafka.CloudEventSerializer;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import se.yolean.kafka.hook.HookCloudEvent;
+import se.yolean.kafka.hook.cloudevents.HookCustomFields;
+
+@RegisterForReflection
+public class HookCloudEventSerializer implements Serializer<HookCloudEvent> {
+
+  final CloudEventSerializer ce;
+
+  public HookCloudEventSerializer() {
+    this(new CloudEventSerializer());
+  }
+
+  HookCloudEventSerializer(CloudEventSerializer ce) {
+    this.ce = ce;
+  }
+
+  @Override
+  public byte[] serialize(String topic, HookCloudEvent data) {
+    throw new UnsupportedOperationException("CloudEventSerializer supports only the signature serialize(String, Headers, CloudEvent)");
+  }
+
+  @Override
+  public byte[] serialize(String topic, Headers headers, HookCloudEvent data) {
+    HookCustomFields hook = data.getCustomFields();
+    for (String key : hook.getKeys()) {
+      headers.add(key, hook.getValueBytes(key));
+    }
+    return ce.serialize(topic, headers, data.getEvent());
+  }
+
+}

--- a/lib/src/test/java/se/yolean/kafka/hook/cloudevents/IncomingWebhookExtensionTest.java
+++ b/lib/src/test/java/se/yolean/kafka/hook/cloudevents/IncomingWebhookExtensionTest.java
@@ -2,7 +2,7 @@ package se.yolean.kafka.hook.cloudevents;
 
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat; 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -51,9 +51,8 @@ public class IncomingWebhookExtensionTest {
 
   @Test
   public void testCapNull() {
-    IncomingWebhookExtension ext = new IncomingWebhookExtension("h_", 1, "");
     try {
-      ext = new IncomingWebhookExtension("h_", 1, null);
+      new IncomingWebhookExtension("h_", 1, null);
     } catch (IllegalArgumentException e) {
       // expected
     }

--- a/lib/src/test/java/se/yolean/kafka/hook/serdes/HookCloudEventSerializerTest.java
+++ b/lib/src/test/java/se/yolean/kafka/hook/serdes/HookCloudEventSerializerTest.java
@@ -1,0 +1,46 @@
+package se.yolean.kafka.hook.serdes;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.net.URI;
+import java.util.Set;
+
+import org.apache.kafka.common.header.Headers;
+import org.junit.jupiter.api.Test;
+
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import io.cloudevents.kafka.CloudEventSerializer;
+import se.yolean.kafka.hook.HookCloudEvent;
+import se.yolean.kafka.hook.cloudevents.HookCustomFields;
+
+class HookCloudEventSerializerTest {
+
+  @Test
+  void testSerializeStringHeadersHookCloudEvent() {
+    final CloudEvent event = CloudEventBuilder.v1()
+        .withId("000")
+        .withType("example.demo")
+        .withSource(URI.create("http://example.com"))
+        .withData("text/plain","Hello world!".getBytes())
+        .build();
+    HookCustomFields custom = mock(HookCustomFields.class);
+    when(custom.getKeys()).thenReturn(Set.of("hook_x-auth-subject", "hook_user-agent"));
+    when(custom.getValueBytes("hook_x-auth-subject")).thenReturn("012".getBytes());
+    when(custom.getValueBytes("hook_user-agent")).thenReturn("Test".getBytes());
+    HookCloudEvent message = mock(HookCloudEvent.class);
+    when(message.getEvent()).thenReturn(event);
+    when(message.getCustomFields()).thenReturn(custom);
+    CloudEventSerializer ceSerializer = mock(CloudEventSerializer.class);
+    HookCloudEventSerializer serializer = new HookCloudEventSerializer(ceSerializer);
+    Headers headers = mock(Headers.class);
+    String topic = "t";
+    serializer.serialize(topic, headers, message);
+    verify(headers).add("hook_x-auth-subject", "012".getBytes());
+    verify(headers).add("hook_user-agent", "Test".getBytes());
+    verify(ceSerializer).serialize(topic, headers, message.getEvent());
+    serializer.close();
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,13 +25,13 @@
   <properties>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <maven.compiler.target>11</maven.compiler.target>
-    <quarkus.platform.version>1.10.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.10.5.Final</quarkus.platform.version>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <quarkus-plugin.version>1.10.3.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.10.5.Final</quarkus-plugin.version>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <!-- keep in sync with quarkus defaults -->

--- a/rest/src/main/resources/application.properties
+++ b/rest/src/main/resources/application.properties
@@ -16,7 +16,7 @@ cloudevent.source-host=http://${HOSTNAME:kafka-hook}
 
 # For native builds take note of reflection-config.json
 outgoing.hook.key.serializer=io.quarkus.kafka.client.serialization.ObjectMapperSerializer
-outgoing.hook.value.serializer=se.yolean.kafka.hook.serdes.CloudEventSerializer
+outgoing.hook.value.serializer=se.yolean.kafka.hook.serdes.HookCloudEventSerializer
 
 outgoing.hook.acks=all
 outgoing.hook.enable.idempotence=true

--- a/rest/src/test/java/se/yolean/kafka/hook/rest/KafkaHookResourceIntegrationTest.java
+++ b/rest/src/test/java/se/yolean/kafka/hook/rest/KafkaHookResourceIntegrationTest.java
@@ -151,9 +151,9 @@ public class KafkaHookResourceIntegrationTest {
     assertEquals("test1", record1.value());
     assertEquals("test2", record2.value());
     consumer.commitSync();
-    assertThat(headers(record2).keySet(), hasItems("ce_hook_x-forwarded-for"));
-    assertEquals("127.0.0.1", headers(record2).get("ce_hook_x-forwarded-for"));
-    assertThat(headers(record2).keySet(), not(hasItems("ce_hook_cookie")));
+    assertThat(headers(record2).keySet(), hasItems("hook_x-forwarded-for"));
+    assertEquals("127.0.0.1", headers(record2).get("hook_x-forwarded-for"));
+    assertThat(headers(record2).keySet(), not(hasItems("hook_cookie")));
     // types from default config
     assertThat(headers(record1).keySet(), hasItems("ce_type"));
     assertEquals("github.com/Yolean/kafka-hook/", headers(record1).get("ce_type"));


### PR DESCRIPTION
... to avoid violating the [cloudevents spec](https://github.com/cloudevents/spec/blob/master/spec.md#attribute-naming-convention).